### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",
-    "react": "^^16.6.0",
+    "react": "^16.6.0",
     "react-dom": "^16.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I believe the double caret in peerDependencies.react was a typo. npm complains: "npm WARN use-react-hooks@1.0.7 requires a peer of react@^^16.6.0".